### PR TITLE
Fix #7 - Histogram of distribution of error and warning types is wrong

### DIFF
--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/ExcelExporter.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/ExcelExporter.java
@@ -63,10 +63,10 @@ public class ExcelExporter {
             while (i.hasNext()) {
                 Feed f = (Feed) i.next();
                 if (f.getErrorList().size() > 0 && f.getErrorList().size() < HISTOGRAM_WIDTH) {
-                    numberOfErrors[f.getErrorList().size()]++;
+                    numberOfErrors[f.getErrorList().size()-1]++;
                 }
                 if (f.getWarningList().size() > 0 && f.getWarningList().size() < HISTOGRAM_WIDTH) {
-                    numberOfWarnings[f.getWarningList().size()]++;
+                    numberOfWarnings[f.getWarningList().size()-1]++;
                 }
             }
         }


### PR DESCRIPTION
**Summary:**

Indexing of the errors in the histogram is off by one, it has now been corrected.

**Expected behavior:** 

Histogram shows correct error frequency.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
