### PR TITLE
Fix #25 - Add option to skip downloading GTFS data if already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Run the [Main.main()](https://github.com/CUTR-at-USF/transit-feed-quality-calcul
 * `-directory "output"` - **Required** - The directory to which feeds will be downloaded (in this case `output`), and to which validation and analysis files will be output
 * `-transitfeedsapikey YOUR_API_KEY` - *(Optional)* - Your [TransitFeeds.com API](http://transitfeeds.com/api/) key (in this case, `YOUR_API_KEY`)
 * `-csv "feeds.csv"` - *(Optional)* - A CSV file holding feed information (in this case, `feeds.csv` - you can name it whatever you want)
+* `-forcegtfsdownload false` - *(Optional)* - If `false`, if there is already a GTFS file on disk for a feed it will not download a new GTFS file.  If `true` or if the command-line option is omitted, then a new GTFS file will always be downloaded and overwrite any current GTFS file for each feed.
 
 If you want to download feeds, either `-transitfeedsapikey` or `-csv` parameters must be provided.  If these are missing, this tool will proceed to validate and analyze the feeds currently in `-directory` without downloading any new files.
 

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/Main.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/Main.java
@@ -25,6 +25,7 @@ public class Main {
     private final static String DIRECTORY = "directory";
     private final static String TRANSIT_FEEDS_API_KEY = "transitfeedsapikey";
     private final static String CSV_PATH_AND_FILE = "csv";
+    private final static String FORCE_GTFS_DOWNLOAD = "forcegtfsdownload";
 
     /**
      * Downloads, validates, and analyzes all GTFS-realtime feeds from TransitFeeds.com and outputs to the provided directory
@@ -38,6 +39,7 @@ public class Main {
         String directoryName = getDirectoryFromArgs(options, args);
         String transitFeedsApiKey = getTransitFeedsApiKeyFromArgs(options, args);
         String csvFile = getCsvPathAndFileFromArgs(options, args);
+        String forceGtfsDownload = getForceGtfsDownloadFromArgs(options, args);
 
         if (directoryName == null) {
             System.err.println("You must provide a directory such as `-directory output`");
@@ -50,6 +52,9 @@ public class Main {
         }
         if (csvFile != null) {
             calculator.setCsvDownloaderFile(csvFile);
+        }
+        if (forceGtfsDownload != null && (forceGtfsDownload.contains("false") || forceGtfsDownload.contains("no"))) {
+            calculator.setForceDownloadGtfs(false);
         }
         calculator.calculate();
     }
@@ -71,10 +76,15 @@ public class Main {
                 .hasArg()
                 .desc("The path and file name of the CSV file that contains feeds to be downloaded")
                 .build();
+        Option forceGtfsDownload = Option.builder(FORCE_GTFS_DOWNLOAD)
+                .hasArg()
+                .desc("True if the GTFS zip file should be downloaded even if it already exists on disk, false if it should not")
+                .build();
 
         options.addOption(downloadDirectory);
         options.addOption(transitFeedsApiKey);
         options.addOption(csvPath);
+        options.addOption(forceGtfsDownload);
         return options;
     }
 
@@ -106,5 +116,15 @@ public class Main {
             pathAndFile = cmd.getOptionValue(CSV_PATH_AND_FILE);
         }
         return pathAndFile;
+    }
+
+    private static String getForceGtfsDownloadFromArgs(Options options, String[] args) throws ParseException {
+        String force = null;
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+        if (cmd.hasOption(FORCE_GTFS_DOWNLOAD)) {
+            force = cmd.getOptionValue(FORCE_GTFS_DOWNLOAD);
+        }
+        return force;
     }
 }

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/TransitFeedQualityCalculator.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/TransitFeedQualityCalculator.java
@@ -33,6 +33,7 @@ public class TransitFeedQualityCalculator {
     private String mTransitFeedsApiKey = null;
     private String mCsvDownloaderFile = null;
     private boolean mDownloadFeeds = true;
+    private boolean mForceDownloadGtfs = true;
     private boolean mValidateFeeds = true;
     private String mErrorsToIgnore = "E017"; // Comma separated string of errors to ignore
     private String mWarningsToIgnore = ""; // Comma separated string of warnings to ignore
@@ -66,6 +67,14 @@ public class TransitFeedQualityCalculator {
     }
 
     /**
+     * Set to true if the GTFS file should be downloaded again even if it already exists on disk for each feed, or false if the file should not be downloaded if it already exists
+     * @param forceDownloadGtfs true if the GTFS file should be downloaded again even if it already exists on disk for each feed, or false if the file should not be downloaded if it already exists
+     */
+    public void setForceDownloadGtfs(boolean forceDownloadGtfs) {
+        mForceDownloadGtfs = forceDownloadGtfs;
+    }
+
+    /**
      * Sets if the validator should validate feeds (default), or if it should just analyze the feeds that have already been validated on disk
      *
      * @param validateFeeds true to validate the feeds, or false if feeds should not be validated
@@ -93,12 +102,12 @@ public class TransitFeedQualityCalculator {
             if (mDownloadFeeds) {
                 if (mCsvDownloaderFile != null) {
                     CsvDownloader csvDownloader = new CsvDownloader(mPath, new File(mCsvDownloaderFile));
-                    csvDownloader.downloadFeeds();
+                    csvDownloader.downloadFeeds(mForceDownloadGtfs);
                 }
 
                 if (mTransitFeedsApiKey != null) {
                     TransitFeedsDownloader transitFeedsDownloader = new TransitFeedsDownloader(mPath, mTransitFeedsApiKey);
-                    transitFeedsDownloader.downloadFeeds();
+                    transitFeedsDownloader.downloadFeeds(mForceDownloadGtfs);
                 }
             }
         }

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/BaseDownloader.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/BaseDownloader.java
@@ -44,9 +44,10 @@ public abstract class BaseDownloader {
 
     /**
      * Downloads GTFS feeds from the source specified in the extending classes
+     * @param forceOverwriteGtfs true if the GTFS file should be downloaded again even if it already exists on disk for each feed, or false if the file should not be downloaded if it already exists
      * @throws IOException
      */
-    abstract public void downloadFeeds() throws IOException;
+    abstract public void downloadFeeds(boolean forceOverwriteGtfs) throws IOException;
 
     /**
      * Writes the GTFS or GTFS-realtime feed at the provided feedUrl to the provided folderName and fileName
@@ -54,17 +55,18 @@ public abstract class BaseDownloader {
      * @param folderName
      * @param fileName
      * @param forceOverwrite true if the file should be downloaded again even if it already exists on disk at the provided fileName, or false if the file should not be downloaded if it already exists at fileName
+     * @return true if the file was downloaded, false if it was not
      * @throws IOException
      */
-    protected void writeFeedToFile(URL feedUrl, String folderName, String fileName, boolean forceOverwrite) throws IOException {
+    protected boolean writeFeedToFile(URL feedUrl, String folderName, String fileName, boolean forceOverwrite) throws IOException {
         String fullPath = mPath.resolve(folderName) + File.separator + fileName;
 
         if (!forceOverwrite && Files.exists(Paths.get(fullPath))) {
-            System.out.println(fullPath + " already exists, skipping the download from " + feedUrl.toString());
-            return;
+            System.out.println("Skipping the download from " + feedUrl.toString() + ", " + fullPath + " already exists");
+            return false;
         }
 
         Files.createDirectories(mPath.resolve(folderName));
-        FileUtil.writeUrlToFile(feedUrl, fullPath);
+        return FileUtil.writeUrlToFile(feedUrl, fullPath);
     }
 }

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/BaseDownloader.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/BaseDownloader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * A class that defines common actions for a downloader of GTFS feeds but leaves some implementation to extending classes
@@ -52,10 +53,16 @@ public abstract class BaseDownloader {
      * @param feedUrl full URL (including any API key) to the provided GTFS or GTFS-realtime file
      * @param folderName
      * @param fileName
+     * @param forceOverwrite true if the file should be downloaded again even if it already exists on disk at the provided fileName, or false if the file should not be downloaded if it already exists at fileName
      * @throws IOException
      */
-    protected void writeFeedToFile(URL feedUrl, String folderName, String fileName) throws IOException {
+    protected void writeFeedToFile(URL feedUrl, String folderName, String fileName, boolean forceOverwrite) throws IOException {
         String fullPath = mPath.resolve(folderName) + File.separator + fileName;
+
+        if (!forceOverwrite && Files.exists(Paths.get(fullPath))) {
+            System.out.println(fullPath + " already exists, skipping the download from " + feedUrl.toString());
+            return;
+        }
 
         Files.createDirectories(mPath.resolve(folderName));
         FileUtil.writeUrlToFile(feedUrl, fullPath);

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/CsvDownloader.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/CsvDownloader.java
@@ -70,7 +70,8 @@ public class CsvDownloader extends BaseDownloader {
                 gtfsRtFeedUrl = new URL(feed.getGtfsRtUrl());
                 writeFeedToFile(gtfsRtFeedUrl,
                         FileUtil.getFolderName(null, feed.getRegionId()),
-                        FileUtil.getGtfsRtFileName(feed.getTitle()));
+                        FileUtil.getGtfsRtFileName(feed.getTitle()),
+                        true);
                 mNumGtfsRtFeeds++;
             } catch (MalformedURLException e) {
                 System.err.println("Malformed Url '" + feed.getGtfsRtUrl() + "' - " + e);
@@ -83,7 +84,6 @@ public class CsvDownloader extends BaseDownloader {
             try {
                 if (mGtfsUrls.contains(feed.getGtfsUrl())) {
                     // We've already downloaded this GTFS data for another GTFS-rt URL record in the CSV file - skip to next record
-                    System.out.println("Already downloaded " + feed.getGtfsUrl() + " from another GTFS-rt feed in the CSV, skipping download");
                     System.out.println("Downloaded GTFS-realtime for " + feed.getTitle() + " (GTFS already downloaded from " + feed.getGtfsUrl() + " for another CSV record)");
                     continue;
                 }
@@ -91,7 +91,7 @@ public class CsvDownloader extends BaseDownloader {
                 gtfsFeedUrl = new URL(feed.getGtfsUrl());
                 writeFeedToFile(gtfsFeedUrl,
                         FileUtil.getFolderName(null, feed.getRegionId()),
-                        FileUtil.getGtfsFileName());
+                        FileUtil.getGtfsFileName(), false);
                 mGtfsUrls.add(feed.getGtfsUrl());
             } catch (MalformedURLException e) {
                 System.err.println("Malformed Url '" + feed.getGtfsUrl() + "' - " + e);

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/TransitFeedsDownloader.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/TransitFeedsDownloader.java
@@ -53,10 +53,11 @@ public class TransitFeedsDownloader extends BaseDownloader {
     /**
      * Downloads feeds from TransitFeeds.com.  This method is synchronous and will return when all the GTFS-realtime
      * and their corresponding GTFS feeds have been downloaded
-     *
+     * @param forceOverwriteGtfs true if the GTFS file should be downloaded again even if it already exists on disk for each feed, or false if the file should not be downloaded if it already exists
      * @throws IOException if TransitFeeds.com API can't be reached, or if writing to the path provided in the constructor fails
      */
-    public void downloadFeeds() throws IOException {
+    @Override
+    public void downloadFeeds(boolean forceOverwriteGtfs) throws IOException {
         System.out.println("Downloading feeds using TransitFeeds.com API...");
         // Loop through all GTFS-realtime feeds and download them
         GetFeedsResponse response = new GetFeedsRequest.Builder(mApiKey)
@@ -91,7 +92,7 @@ public class TransitFeedsDownloader extends BaseDownloader {
         System.out.println("Total GTFS pages = " + totalPages);
 
         while (currentPage <= totalPages) {
-            downloadGtfsFeeds(response.getResults().getFeeds());
+            downloadGtfsFeeds(response.getResults().getFeeds(), forceOverwriteGtfs);
             System.out.println("Downloaded GTFS page = " + currentPage);
 
             if (currentPage < totalPages) {
@@ -140,7 +141,12 @@ public class TransitFeedsDownloader extends BaseDownloader {
         }
     }
 
-    private void downloadGtfsFeeds(List<Feed> gtfsFeeds) {
+    /**
+     * Download the provided list of GTFS feeds
+     * @param gtfsFeeds list of GTFS feeds to be downloaded
+     * @param forceOverwrite true if the GTFS file should be downloaded again even if it already exists on disk for each feed, or false if the file should not be downloaded if it already exists
+     */
+    private void downloadGtfsFeeds(List<Feed> gtfsFeeds, boolean forceOverwrite) {
         URL gtfsFeedUrl;
 
         for (Feed feed : gtfsFeeds) {
@@ -163,7 +169,7 @@ public class TransitFeedsDownloader extends BaseDownloader {
                 }
 
                 try {
-                    writeFeedToFile(gtfsFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsFileName(), false);
+                    writeFeedToFile(gtfsFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsFileName(), forceOverwrite);
                 } catch (IOException e) {
                     System.err.println("Error downloading GTFS feed '" + urlString + "' - " + e);
                     continue;

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/TransitFeedsDownloader.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/downloaders/TransitFeedsDownloader.java
@@ -127,7 +127,7 @@ public class TransitFeedsDownloader extends BaseDownloader {
                 }
 
                 try {
-                    writeFeedToFile(gtfsRtFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsRtFileName(feed.getTitle()));
+                    writeFeedToFile(gtfsRtFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsRtFileName(feed.getTitle()), true);
 
                     // Save the location ID of this GTFS-rt feed, so we know to download the GTFS for it later
                     mGtfsRtLocationIds.add(feed.getLocation().getId());
@@ -163,7 +163,7 @@ public class TransitFeedsDownloader extends BaseDownloader {
                 }
 
                 try {
-                    writeFeedToFile(gtfsFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsFileName());
+                    writeFeedToFile(gtfsFeedUrl, FileUtil.getFolderName(feed), FileUtil.getGtfsFileName(), false);
                 } catch (IOException e) {
                     System.err.println("Error downloading GTFS feed '" + urlString + "' - " + e);
                     continue;

--- a/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/util/FileUtil.java
+++ b/src/main/java/edu/usf/cutr/transitfeedqualitycalculator/util/FileUtil.java
@@ -67,8 +67,9 @@ public class FileUtil {
      *
      * @param url      URL to retrieve
      * @param fileName name of file to write the information to
+     * @return true if the file was downloaded, false if it was not
      */
-    public static void writeUrlToFile(URL url, String fileName) throws IOException {
+    public static boolean writeUrlToFile(URL url, String fileName) throws IOException {
         // Check for HTTP 301 redirect
         URLConnection urlConnection = url.openConnection();
         String redirect = urlConnection.getHeaderField("Location");
@@ -83,7 +84,7 @@ public class FileUtil {
             in = urlConnection.getInputStream();
         } catch (SSLHandshakeException sslEx) {
             System.err.println("SSL handshake failed.  Try installing the JCE Extension or adding `-Djsse.enableSNIExtension=false` when running the application - see https://github.com/CUTR-at-USF/transit-feed-quality-calculator#running-the-application: " + sslEx);
-            return;
+            return false;
         }
 
         byte[] gtfsRtProtobuf = IOUtils.toByteArray(in);
@@ -94,6 +95,7 @@ public class FileUtil {
         fileChannel.write(buffer);
         fileChannel.close();
         fos.close();
+        return true;
     }
 
     /**


### PR DESCRIPTION
~~**Please don't merge**~~

TODO:
- [x] Right now GTFS-realtime downloads are always forced and GTFS downloads aren't - add config option to control whether or not GTFS downloads are forced
- [x] Fix log messages in CSVDownloader that say a download happened when it actually wasn't forced